### PR TITLE
show download instructions in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Options:
 
 ### Example:
 ```
-libsodium-type-generator -o /path/to/libsodium.d.ts -b /path/to/libsodium.js
+curl -L https://github.com/jedisct1/libsodium.js/archive/master.tar.gz -o /path/to/libsodium.tar.gz
+tar -C /path/to/ -zxvf /path/to/libsodium.tar.gz
+libsodium-type-generator -o /path/to/libsodium.d.ts -b /path/to/libsodium.js-master/
 ```
 or
 ```


### PR DESCRIPTION
The example doesn't make it entirely clear that the `--base` option is meant to be run with a compressed download of libsodium, so this PR expands the example with some download commands